### PR TITLE
Add admin dashboard statistics

### DIFF
--- a/Room2Room/Controllers/AdminController.cs
+++ b/Room2Room/Controllers/AdminController.cs
@@ -46,6 +46,71 @@ public class AdminController : Controller
         return View();
     }
 
+    [HttpGet]
+    public async Task<IActionResult> Statistics()
+    {
+        var totalUsers = await _context.Accounts.CountAsync();
+        var totalListings = await _context.Items.CountAsync();
+
+        var listingsByUniversity = await (
+            from item in _context.Items
+            join account in _context.Accounts on item.AccountId equals account.Id
+            join university in _context.Universities on account.UniversityId equals university.Id
+            group item by university.Name into g
+            orderby g.Count() descending, g.Key
+            select new UniversityListingStat
+            {
+                UniversityName = g.Key,
+                ListingCount = g.Count()
+            }
+        ).ToListAsync();
+
+        var listingsByCategory = await (
+            from item in _context.Items
+            join category in _context.Categories on item.CategoryId equals category.Id
+            group item by category.CategoryName into g
+            orderby g.Count() descending, g.Key
+            select new CategoryListingStat
+            {
+                CategoryName = g.Key,
+                ListingCount = g.Count()
+            }
+        ).ToListAsync();
+
+        var topUsersByListings = await (
+            from item in _context.Items
+            join account in _context.Accounts on item.AccountId equals account.Id
+            group item by new
+            {
+                account.Id,
+                account.Email
+            } into g
+            orderby g.Count() descending
+            select new TopUserListingStat
+            {
+                UserDisplayName = g.Key.Email,
+                ListingCount = g.Count()
+            }
+        ).Take(3).ToListAsync();
+
+        var averageListingsPerUser = totalUsers == 0
+            ? 0
+            : Math.Round((double)totalListings / totalUsers, 1);
+
+        var model = new AdminStatisticsViewModel
+        {
+            TotalUsers = totalUsers,
+            TotalListings = totalListings,
+            UniversitiesWithListings = listingsByUniversity.Count,
+            AverageListingsPerUser = averageListingsPerUser,
+            ListingsByUniversity = listingsByUniversity,
+            ListingsByCategory = listingsByCategory,
+            TopUsersByListings = topUsersByListings
+        };
+
+        return PartialView("_Statistics", model);
+    }
+
     // ===== Announcements List =====
     [HttpGet]
     public IActionResult ListAnnouncements()

--- a/Room2Room/Models/DTOs/AdminStatisticsViewModel.cs
+++ b/Room2Room/Models/DTOs/AdminStatisticsViewModel.cs
@@ -1,0 +1,32 @@
+namespace Room2Room.Models.DTOs
+{
+    public class AdminStatisticsViewModel
+    {
+        public int TotalUsers { get; set; }
+        public int TotalListings { get; set; }
+        public int UniversitiesWithListings { get; set; }
+        public double AverageListingsPerUser { get; set; }
+
+        public IEnumerable<UniversityListingStat> ListingsByUniversity { get; set; } = new List<UniversityListingStat>();
+        public IEnumerable<CategoryListingStat> ListingsByCategory { get; set; } = new List<CategoryListingStat>();
+        public IEnumerable<TopUserListingStat> TopUsersByListings { get; set; } = new List<TopUserListingStat>();
+    }
+
+    public class UniversityListingStat
+    {
+        public string UniversityName { get; set; } = string.Empty;
+        public int ListingCount { get; set; }
+    }
+
+    public class CategoryListingStat
+    {
+        public string CategoryName { get; set; } = string.Empty;
+        public int ListingCount { get; set; }
+    }
+
+    public class TopUserListingStat
+    {
+        public string UserDisplayName { get; set; } = string.Empty;
+        public int ListingCount { get; set; }
+    }
+}

--- a/Room2Room/Views/Admin/Index.cshtml
+++ b/Room2Room/Views/Admin/Index.cshtml
@@ -24,6 +24,7 @@
   <div class="tab-pane fade" id="listing-tab-pane" role="tabpanel" aria-labelledby="listing-tab" tabindex="0"><div id="adminListingsContainer"></div></div>
   <div class="tab-pane fade" id="chat-tab-pane" role="tabpanel" aria-labelledby="chat-tab" tabindex="0">...</div>
   <div class="tab-pane fade" id="listing-categories-tab-pane" role="tabpanel" aria-labelledby="listing-categories-tab" tabindex="0">...</div>
-  <div class="tab-pane fade" id="statistics-tab-pane" role="tabpanel" aria-labelledby="statistics-tab" tabindex="0">...</div>
+  <div class="tab-pane fade" id="statistics-tab-pane" role="tabpanel" aria-labelledby="statistics-tab" tabindex="0"><div id="adminStatisticsContainer"></div></div>
 </div>
 <script src="~/js/adminListings.js"></script>
+<script src="~/js/adminStatistics.js"></script>

--- a/Room2Room/Views/Admin/_Statistics.cshtml
+++ b/Room2Room/Views/Admin/_Statistics.cshtml
@@ -1,0 +1,224 @@
+@model Room2Room.Models.DTOs.AdminStatisticsViewModel
+
+@{
+    int totalUniversityListings = Model.ListingsByUniversity.Sum(x => x.ListingCount);
+    int totalCategoryListings = Model.ListingsByCategory.Sum(x => x.ListingCount);
+}
+
+<div class="my-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+            <h3 class="mb-1">Admin Statistics</h3>
+            <p class="text-muted mb-0">Overview of current platform activity.</p>
+        </div>
+    </div>
+
+    <div class="row g-4 mb-4">
+        <div class="col-md-3">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex align-items-start gap-3">
+                    <div class="rounded-circle bg-dark-subtle d-flex align-items-center justify-content-center" style="width: 42px; height: 42px;">
+                        <span class="fw-bold text-dark">U</span>
+                    </div>
+                    <div>
+                        <p class="text-muted text-uppercase small mb-2">Users</p>
+                        <h2 class="mb-1">@Model.TotalUsers</h2>
+                        <p class="mb-0 text-muted small">Total registered accounts</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-3">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex align-items-start gap-3">
+                    <div class="rounded-circle bg-primary-subtle d-flex align-items-center justify-content-center" style="width: 42px; height: 42px;">
+                        <span class="fw-bold text-primary">L</span>
+                    </div>
+                    <div>
+                        <p class="text-muted text-uppercase small mb-2">Listings</p>
+                        <h2 class="mb-1">@Model.TotalListings</h2>
+                        <p class="mb-0 text-muted small">Total listings in the system</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-3">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex align-items-start gap-3">
+                    <div class="rounded-circle bg-success-subtle d-flex align-items-center justify-content-center" style="width: 42px; height: 42px;">
+                        <span class="fw-bold text-success">S</span>
+                    </div>
+                    <div>
+                        <p class="text-muted text-uppercase small mb-2">Universities</p>
+                        <h2 class="mb-1">@Model.UniversitiesWithListings</h2>
+                        <p class="mb-0 text-muted small">Universities that currently have listings</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-3">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex align-items-start gap-3">
+                    <div class="rounded-circle bg-warning-subtle d-flex align-items-center justify-content-center" style="width: 42px; height: 42px;">
+                        <span class="fw-bold text-warning">A</span>
+                    </div>
+                    <div>
+                        <p class="text-muted text-uppercase small mb-2">Avg Listings / User</p>
+                        <h2 class="mb-1">@Model.AverageListingsPerUser</h2>
+                        <p class="mb-0 text-muted small">Average number of listings per user</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4">
+        <div class="col-lg-6">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body">
+                    <div class="mb-3">
+                        <h4 class="mb-1">Listings by University</h4>
+                        <p class="text-muted mb-0 small">Counts the number of listings grouped by university.</p>
+                    </div>
+
+                    @if (Model.ListingsByUniversity.Any())
+                    {
+                        <div class="table-responsive">
+                            <table class="table align-middle mb-0">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th>University</th>
+                                        <th style="width: 45%;">Distribution</th>
+                                        <th class="text-end">Count</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (UniversityListingStat stat in Model.ListingsByUniversity)
+                                    {
+                                        int widthPercent = totalUniversityListings == 0 ? 0 : (int)Math.Round((double)stat.ListingCount / totalUniversityListings * 100);
+
+                                        <tr>
+                                            <td class="fw-medium">@stat.UniversityName</td>
+                                            <td>
+                                                <div class="d-flex align-items-center gap-3">
+                                                    <div class="progress flex-grow-1" style="height: 12px;">
+                                                        <div class="progress-bar bg-dark" style="width: @widthPercent%"></div>
+                                                    </div>
+                                                    <span class="text-muted small">@widthPercent%</span>
+                                                </div>
+                                            </td>
+                                            <td class="text-end fw-medium">@stat.ListingCount</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="text-muted">No statistics available.</div>
+                    }
+                </div>
+            </div>
+        </div>
+
+        <div class="col-lg-6">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body">
+                    <div class="mb-3">
+                        <h4 class="mb-1">Listings by Category</h4>
+                        <p class="text-muted mb-0 small">Counts the number of listings grouped by category.</p>
+                    </div>
+
+                    @if (Model.ListingsByCategory.Any())
+                    {
+                        <div class="table-responsive">
+                            <table class="table align-middle mb-0">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th>Category</th>
+                                        <th style="width: 45%;">Distribution</th>
+                                        <th class="text-end">Count</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (CategoryListingStat stat in Model.ListingsByCategory)
+                                    {
+                                        int widthPercent = totalCategoryListings == 0 ? 0 : (int)Math.Round((double)stat.ListingCount / totalCategoryListings * 100);
+
+                                        <tr>
+                                            <td class="fw-medium">@stat.CategoryName</td>
+                                            <td>
+                                                <div class="d-flex align-items-center gap-3">
+                                                    <div class="progress flex-grow-1" style="height: 12px;">
+                                                        <div class="progress-bar bg-secondary" style="width: @widthPercent%"></div>
+                                                    </div>
+                                                    <span class="text-muted small">@widthPercent%</span>
+                                                </div>
+                                            </td>
+                                            <td class="text-end fw-medium">@stat.ListingCount</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="text-muted">No category statistics available.</div>
+                    }
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12">
+            <div class="card border-0 shadow-sm">
+                <div class="card-body">
+                    <div class="mb-3">
+                        <h4 class="mb-1">Top 3 Users by Listings</h4>
+                        <p class="text-muted mb-0 small">Users with the highest number of listings.</p>
+                    </div>
+
+                    @if (Model.TopUsersByListings.Any())
+                    {
+                        <div class="table-responsive">
+                            <table class="table align-middle mb-0">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th style="width: 90px;">Rank</th>
+                                        <th>User</th>
+                                        <th class="text-end">Listings</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @{
+                                        var rank = 1;
+                                    }
+                                    @foreach (TopUserListingStat user in Model.TopUsersByListings)
+                                    {
+                                        string medal = rank == 1 ? "🥇" : rank == 2 ? "🥈" : "🥉";
+
+                                        <tr>
+                                            <td class="fw-medium">@medal #@rank</td>
+                                            <td>@user.UserDisplayName</td>
+                                            <td class="text-end fw-medium">@user.ListingCount</td>
+                                        </tr>
+
+                                        rank++;
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="text-muted">No user statistics available.</div>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Room2Room/wwwroot/js/adminStatistics.js
+++ b/Room2Room/wwwroot/js/adminStatistics.js
@@ -1,0 +1,24 @@
+document.addEventListener("DOMContentLoaded", function() {
+    const statisticsTab = document.getElementById("statistics-tab");
+
+    if (statisticsTab) {
+        statisticsTab.addEventListener("click", function () {
+            loadAdminStatistics();
+        });
+    }
+});
+
+function loadAdminStatistics() {
+    fetch('/Admin/Statistics')
+        .then(response => {
+            if (!response.ok) throw new Error("Network response was not ok");
+            return response.text();
+        })
+        .then(html => {
+            const container = document.getElementById('adminStatisticsContainer');
+            if (container) container.innerHTML = html;
+        })
+        .catch(error => {
+            console.error('Error loading admin statistics:', error);
+        });
+}


### PR DESCRIPTION
Added the statistics tab content for the admin dashboard.

This includes:
- total user count
- total listing count
- universities with listings
- average listings per user
- listings grouped by university
- listings grouped by category
- top 3 users with the most listings